### PR TITLE
Feature/location search Add Places API to allow location tagging to diary entries

### DIFF
--- a/life-map/db/db.js
+++ b/life-map/db/db.js
@@ -1,20 +1,20 @@
-const mysql = require('mysql2')
+const mysql = require("mysql2");
 
 var pool = mysql.createPool({
-    multipleStatements: true,
-    host: '192.168.64.2',
-    user: 'root',
-    password: '',
-    database: 'orbital_development',
-    waitForConnections: true,
-    connectionLimit: 10,
-    queueLimit: 0
-})
+  multipleStatements: true,
+  host: "localhost",
+  user: "root",
+  password: "",
+  database: "orbital_development",
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+});
 
-const crud = require('./crud.js')(pool)
+const crud = require("./crud.js")(pool);
 
-const user_auth = require('./db_includes/user_auth.js')(crud)
-const markers = require('./db_includes/markers.js')(crud)
-const diary = require('./db_includes/diary_entries.js')(crud)
+const user_auth = require("./db_includes/user_auth.js")(crud);
+const markers = require("./db_includes/markers.js")(crud);
+const diary = require("./db_includes/diary_entries.js")(crud);
 
-module.exports = {...user_auth, ...markers, ...diary}
+module.exports = { ...user_auth, ...markers, ...diary };

--- a/life-map/db/db.js
+++ b/life-map/db/db.js
@@ -2,14 +2,14 @@ const mysql = require('mysql2')
 
 var pool = mysql.createPool({
     multipleStatements: true,
-    host: 'localhost',
+    host: '192.168.64.2',
     user: 'root',
     password: '',
     database: 'orbital_development',
     waitForConnections: true,
     connectionLimit: 10,
     queueLimit: 0
-})  
+})
 
 const crud = require('./crud.js')(pool)
 

--- a/life-map/package-lock.json
+++ b/life-map/package-lock.json
@@ -11316,6 +11316,11 @@
         "warning": "^4.0.3"
       }
     },
+    "react-cool-onclickoutside": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/react-cool-onclickoutside/-/react-cool-onclickoutside-1.4.8.tgz",
+      "integrity": "sha512-FgM1mXtDTA3FOkrArp0Hn1G4G4TKhy/2Yls77bHC1OoBo8uXErhxVcQbYRfZ+xvGDPx07s74GjHH64SNKjqpqg=="
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",

--- a/life-map/package-lock.json
+++ b/life-map/package-lock.json
@@ -8349,6 +8349,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14117,6 +14122,14 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-places-autocomplete": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/use-places-autocomplete/-/use-places-autocomplete-1.3.5.tgz",
+      "integrity": "sha512-CuRSLbmNeLKaXgEhZbuvCnnJVPDmCVXB7WoxCafEMLA9UaowN+pRM2UoqLWpuUrArKpBn7uUCGwEwyWOA1YVAg==",
+      "requires": {
+        "lodash.debounce": "^4.0.8"
+      }
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -14335,7 +14348,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -14396,7 +14408,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }

--- a/life-map/package.json
+++ b/life-map/package.json
@@ -26,7 +26,8 @@
     "react-facebook-login": "^4.1.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
-    "styled-components": "^5.1.0"
+    "styled-components": "^5.1.0",
+    "use-places-autocomplete": "^1.3.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/life-map/package.json
+++ b/life-map/package.json
@@ -22,6 +22,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
+    "react-cool-onclickoutside": "^1.4.8",
     "react-dom": "^16.13.1",
     "react-facebook-login": "^4.1.1",
     "react-router-dom": "^5.2.0",

--- a/life-map/public/index.html
+++ b/life-map/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,15 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <script
+    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCKRP5jhXmVYo2r5FiWMUobmufY4u8Llz4&libraries=places"></script>
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +40,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/life-map/src/components/AddEntry.js
+++ b/life-map/src/components/AddEntry.js
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import usePlacesAutocomplete, {
   getGeocode,
   getLatLng,
 } from "use-places-autocomplete";
+import useOnclickOutside from "react-cool-onclickoutside";
 
 const config = {
   withCredentials: true,
@@ -36,7 +37,7 @@ const AddEntry = () => {
         lng: () => 103.8198,
       },
       // radius in metres
-      radius: 40 * 1000,
+      radius: 20 * 1000,
     },
   });
 
@@ -80,21 +81,25 @@ const AddEntry = () => {
       location,
     };
 
-    // const {
-    //   data: { success, message },
-    // } = await axios.post(
-    //   "http://localhost:5000/homepage/create-entry",
-    //   payload,
-    //   config
-    // );
+    const {
+      data: { success, message },
+    } = await axios.post(
+      "http://localhost:5000/homepage/create-entry",
+      payload,
+      config
+    );
 
-    // setResponseMessage(message);
+    setResponseMessage(message);
   };
+
+  /* declare dom ref to close when user clicks outside the dropdown list */
+  const dropDownRef = useRef();
+  useOnclickOutside(dropDownRef, clearSuggestions);
 
   /* Func comp to show suggestions in a drop-down list */
   const Suggestions = () => {
     return (
-      <div style={{ border: "1px solid grey" }}>
+      <div ref={dropDownRef} style={{ border: "1px solid grey" }}>
         {data.map((suggestion) => {
           const { description, place_id } = suggestion;
 
@@ -120,8 +125,10 @@ const AddEntry = () => {
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
+
       <Label>Content</Label>
       <TextArea value={content} onChange={(e) => setContent(e.target.value)} />
+
       <Label>Location</Label>
       <TextInput
         type="text"
@@ -132,6 +139,7 @@ const AddEntry = () => {
       />
       {/* preconditions to check before rendering autocomplete results */}
       {ready && status === "OK" && status !== "ZERO_RESULTS" && <Suggestions />}
+
       <CheckBoxContainer>
         <input
           type="checkbox"
@@ -144,6 +152,7 @@ const AddEntry = () => {
           onChange={() => setShared((prev) => !prev)}
           checked={shared}
         />
+
         <p
           style={{ cursor: "pointer" }}
           onClick={() => setShared((prev) => !prev)}
@@ -151,9 +160,11 @@ const AddEntry = () => {
           Share with friends
         </p>
       </CheckBoxContainer>
+
       <FormButton type="submit" style={{ marginTop: "24px" }}>
         Save
       </FormButton>
+
       <p style={{ height: "30px", color: "red", textAlign: "center" }}>
         {responseMessage}
       </p>

--- a/life-map/src/components/AddEntry.js
+++ b/life-map/src/components/AddEntry.js
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
+import usePlacesAutocomplete, {
+  getGeocode,
+  getLatLng,
+} from "use-places-autocomplete";
 
 const config = {
   withCredentials: true,
@@ -13,8 +17,59 @@ const AddEntry = () => {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [shared, setShared] = useState(false);
-  const [location, setLocation] = useState("");
+  const [location, setLocation] = useState({});
   const [responseMessage, setResponseMessage] = useState("");
+
+  /* initialize Places API */
+  const {
+    ready,
+    value: locationInput,
+    suggestions: { status, data },
+    setValue: setLocationInput,
+    clearSuggestions,
+  } = usePlacesAutocomplete({
+    // configure location-biasing for suggestions
+    requestOptions: {
+      // center of singapore
+      location: {
+        lat: () => 1.3521,
+        lng: () => 103.8198,
+      },
+      // radius in metres
+      radius: 40 * 1000,
+    },
+  });
+
+  /* when a Place suggestion is clicked */
+  const handleSelectPlace = (suggestion) => {
+    const {
+      description,
+      place_id: placeId,
+      structured_formatting: { main_text },
+    } = suggestion;
+
+    // get lat/lng
+    getGeocode({ placeId })
+      .then((results) => getLatLng(results[0]))
+      .then((latLngObject) => {
+        const { lat, lng } = latLngObject;
+
+        setLocation({
+          name: main_text,
+          address: description,
+          lat,
+          lng,
+        });
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+
+    // reset input field
+    setLocationInput(description, false);
+    // close drop-down list
+    clearSuggestions();
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -22,22 +77,38 @@ const AddEntry = () => {
       title,
       content,
       shared,
+      location,
     };
 
-    console.log("submitting", payload);
+    // const {
+    //   data: { success, message },
+    // } = await axios.post(
+    //   "http://localhost:5000/homepage/create-entry",
+    //   payload,
+    //   config
+    // );
 
-    const {
-      data: { success, message },
-    } = await axios.post(
-      "http://localhost:5000/homepage/create-entry",
-      payload,
-      config
+    // setResponseMessage(message);
+  };
+
+  /* Func comp to show suggestions in a drop-down list */
+  const Suggestions = () => {
+    return (
+      <div style={{ border: "1px solid grey" }}>
+        {data.map((suggestion) => {
+          const { description, place_id } = suggestion;
+
+          return (
+            <SuggestionTag
+              key={place_id}
+              onClick={() => handleSelectPlace(suggestion)}
+            >
+              {description}
+            </SuggestionTag>
+          );
+        })}
+      </div>
     );
-
-    console.log("response received", success);
-    console.log("reponse msg", message);
-
-    setResponseMessage(message);
   };
 
   return (
@@ -55,9 +126,12 @@ const AddEntry = () => {
       <TextInput
         type="text"
         placeholder="type to search"
-        value={location}
-        onChange={(e) => setLocation(e.target.value)}
+        value={locationInput}
+        onChange={(e) => setLocationInput(e.target.value)}
+        style={{ marginBottom: "0" }}
       />
+      {/* preconditions to check before rendering autocomplete results */}
+      {ready && status === "OK" && status !== "ZERO_RESULTS" && <Suggestions />}
       <CheckBoxContainer>
         <input
           type="checkbox"
@@ -138,4 +212,13 @@ const CheckBoxContainer = styled.div`
   align-items: center;
   font-size: 1.1em;
   letter-spacing: 1px;
+`;
+
+const SuggestionTag = styled.div`
+  padding: 8px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(85, 85, 85, 0.1);
+  }
 `;

--- a/life-map/src/pages/Home.js
+++ b/life-map/src/pages/Home.js
@@ -49,8 +49,8 @@ const Home = ({
         setLoading(false);
       }
 
-    const markers = await axios.get("http://localhost:5000/homepage", config);
-    setMarkers(markers.data.data);
+      const markers = await axios.get("http://localhost:5000/homepage", config);
+      setMarkers(markers.data.data);
     })();
 
     return () => {
@@ -98,7 +98,7 @@ const Home = ({
             <MapContainer>
               <GoogleMapReact
                 // populate api key
-                bootstrapURLKeys={{ key: "AIzaSyCKRP5jhXmVYo2r5FiWMUobmufY4u8Llz4" }}
+                bootstrapURLKeys={{ key: "" }}
                 defaultCenter={mapDefaults.center}
                 defaultZoom={mapDefaults.zoom}
                 // somehow you need to do this cos of some bug in the package

--- a/life-map/src/pages/Home.js
+++ b/life-map/src/pages/Home.js
@@ -49,11 +49,9 @@ const Home = ({
         setLoading(false);
       }
 
-    // const markers = await axios.get("http://localhost:5000/homepage", config);
-    // setMarkers(markers.data.data);
+    const markers = await axios.get("http://localhost:5000/homepage", config);
+    setMarkers(markers.data.data);
     })();
-    // setLoading(false);
-    // setLoggedIn(true);
 
     return () => {
       mounted = false;
@@ -100,7 +98,7 @@ const Home = ({
             <MapContainer>
               <GoogleMapReact
                 // populate api key
-                bootstrapURLKeys={{ key: "" }}
+                bootstrapURLKeys={{ key: "AIzaSyCKRP5jhXmVYo2r5FiWMUobmufY4u8Llz4" }}
                 defaultCenter={mapDefaults.center}
                 defaultZoom={mapDefaults.zoom}
                 // somehow you need to do this cos of some bug in the package

--- a/life-map/src/pages/Landing.js
+++ b/life-map/src/pages/Landing.js
@@ -85,7 +85,6 @@ const Login = ({ loginRef, registerRef, redirect }) => {
     event.preventDefault();
 
     const response = await authCheck();
-    // const response = { success: true, name: "sam" };
 
     if (response.success) {
       redirect(response.name);


### PR DESCRIPTION
Added Places API. When typing in the location field of the add-entry form, a dropdown list should appear with location suggestions from Google Maps Places API. 

On selecting the location, we should get the full name, coordinates, and google place_id of the location. 

On save, the request to the backend now contains a location field. The object is of this shape: 
```
{
    name: String,
    address: String,
    lat: Number,
    lng: Number
}
```

We can then add tweak the create-entry endpoint appropriately to take in location data. Let me know if an alternate data shape is preferred.